### PR TITLE
fix the issue that Base58 format private key is recognized incorrectl…

### DIFF
--- a/app/src/main/java/com/solana/mwallet/MobileWalletAdapterViewModel.kt
+++ b/app/src/main/java/com/solana/mwallet/MobileWalletAdapterViewModel.kt
@@ -342,10 +342,12 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
         // first check if a private key was provided through local props
         return BuildConfig.PRIVATE_KEY?.let { privateKey ->
             val privateKeyRaw = try {
-                val standardBase64NoPadding = privateKey.replace("-", "+").replace("_", "/").trimEnd('=')
-                Base64.decode(standardBase64NoPadding, Base64.NO_PADDING or Base64.NO_WRAP)
-            } catch (_: IllegalArgumentException) {
-                try { Base58.decode(privateKey) } catch (_: Error) {
+                Base58.decode(privateKey)
+            } catch (_: Throwable) {
+                try {
+                    val standardBase64NoPadding = privateKey.replace("-", "+").replace("_", "/").trimEnd('=')
+                    Base64.decode(standardBase64NoPadding, Base64.NO_PADDING or Base64.NO_WRAP)
+                } catch (_: IllegalArgumentException) {
                     throw IllegalArgumentException("could not decode provided private key from local props")
                 }
             }


### PR DESCRIPTION
**Issue:** 
The MobileWalletAdapterViewModel attempted to decode the injected private key as Base64 before Base58. Since many standard Solana Base58 private keys are also technically valid Base64 strings (containing only alphanumeric characters), they were being incorrectly decoded as Base64. This resulted in the derivation of an incorrect seed and wallet address.

**How to reproduce the issue:**
Private Key: 2v9zYqCpUwnxnyhDdtiSbdDxLgLKMdwHgCUFmYBVpBGtatZCRTrQdVDQD8CVwrFHfAz7jRLZPS2KkqjqsVyD3TAu
Public Key: b9NqoWsrUhxGnfwZcWqX6dFsjre8JqvGsssqvjLwS6q
incorrect calculated public key: 3USUB3s962grBZtpu9c6D6gftMA5rsG3vXjuUxppKwYf

**Fix:** 
Prioritized Base58 decoding over Base64. The app now attempts to decode the private key as Base58 first, ensuring standard Solana keys are interpreted correctly. Base64 is only attempted if Base58 decoding fails.