### PR TITLE
feat: show configured public key

### DIFF
--- a/app/src/main/java/com/solana/mwallet/LocalKeypair.kt
+++ b/app/src/main/java/com/solana/mwallet/LocalKeypair.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 Solana Mobile Inc.
+ */
+
+package com.solana.mwallet
+
+import android.util.Base64
+import com.funkatronics.encoders.Base58
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+
+object LocalKeypair {
+    fun getPrivateKey(): ByteArray? =
+        BuildConfig.PRIVATE_KEY?.let(::decodePrivateKey)
+
+    fun getPublicKey(): String? =
+        getPrivateKey()?.let { privateKey ->
+            val privateKeyParams = Ed25519PrivateKeyParameters(privateKey, 0)
+            Base58.encodeToString(privateKeyParams.generatePublicKey().encoded)
+        }
+
+    private fun decodePrivateKey(privateKey: String): ByteArray =
+        try {
+            Base58.decode(privateKey)
+        } catch (_: Throwable) {
+            try {
+                val standardBase64NoPadding = privateKey.replace("-", "+").replace("_", "/").trimEnd('=')
+                Base64.decode(standardBase64NoPadding, Base64.NO_PADDING or Base64.NO_WRAP)
+            } catch (_: IllegalArgumentException) {
+                throw IllegalArgumentException("could not decode provided private key from local props")
+            }
+        }
+}

--- a/app/src/main/java/com/solana/mwallet/MainActivity.kt
+++ b/app/src/main/java/com/solana/mwallet/MainActivity.kt
@@ -5,11 +5,11 @@
 package com.solana.mwallet
 
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import com.solana.mobilewalletadapter.walletlib.association.RemoteAssociationUri
 import com.solana.mwallet.databinding.ActivityMainBinding
 import com.solana.mwallet.usecase.UserAuthenticationUseCase
@@ -22,6 +22,8 @@ class MainActivity : AppCompatActivity() {
 
         viewBinding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(viewBinding.root)
+
+        viewBinding.publicKeyText.text = getPublicKeyText()
 
         viewBinding.button.setOnClickListener {
             UserAuthenticationUseCase.authenticate(this) { result , error ->
@@ -62,4 +64,9 @@ class MainActivity : AppCompatActivity() {
     private fun openBarcodeScanner() {
         startActivity(Intent(applicationContext, BarcodeScannerActivity::class.java))
     }
+
+    private fun getPublicKeyText(): String =
+        runCatching { LocalKeypair.getPublicKey() }.getOrNull()
+            ?.let { "Public key: $it" }
+            ?: "Public key not configured"
 }

--- a/app/src/main/java/com/solana/mwallet/MobileWalletAdapterViewModel.kt
+++ b/app/src/main/java/com/solana/mwallet/MobileWalletAdapterViewModel.kt
@@ -9,7 +9,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.security.keystore.UserNotAuthenticatedException
-import android.util.Base64
 import android.util.Log
 import androidx.biometric.BiometricPrompt
 import androidx.lifecycle.AndroidViewModel
@@ -404,17 +403,7 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
 
     private suspend fun getKeypair(): AsymmetricCipherKeyPair {
         // first check if a private key was provided through local props
-        return BuildConfig.PRIVATE_KEY?.let { privateKey ->
-            val privateKeyRaw = try {
-                Base58.decode(privateKey)
-            } catch (_: Throwable) {
-                try {
-                    val standardBase64NoPadding = privateKey.replace("-", "+").replace("_", "/").trimEnd('=')
-                    Base64.decode(standardBase64NoPadding, Base64.NO_PADDING or Base64.NO_WRAP)
-                } catch (_: IllegalArgumentException) {
-                    throw IllegalArgumentException("could not decode provided private key from local props")
-                }
-            }
+        return LocalKeypair.getPrivateKey()?.let { privateKeyRaw ->
             val privateKeyParams = Ed25519PrivateKeyParameters(privateKeyRaw, 0)
             (getApplication<MwalletApplication>().keyRepository.getKeypair(privateKeyParams.generatePublicKey().encoded)
                 ?: AsymmetricCipherKeyPair(

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,11 +20,26 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <TextView
+        android:id="@+id/public_key_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="32dp"
+        android:gravity="center"
+        android:textIsSelectable="true"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/title_text"
+        tools:text="Public key: 11111111111111111111111111111111" />
+
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/title_text"
+        app:layout_constraintTop_toBottomOf="@id/public_key_text"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:text="Authenticate"/>


### PR DESCRIPTION
Display the public key derived from the locally configured private key on the main screen.


Reuse the existing Base58 and Base64 local private key decoding path for both the wallet keypair and displayed public key.

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/8430432c-34a8-4c2d-8d87-16c527f332f6" />
