### PR TITLE
feat: show public key in authorize dialog

### DIFF
--- a/app/src/main/java/com/solana/mwallet/ui/authorizedapp/AuthorizeDappFragment.kt
+++ b/app/src/main/java/com/solana/mwallet/ui/authorizedapp/AuthorizeDappFragment.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
+import com.solana.mwallet.LocalKeypair
 import com.solana.mwallet.MobileWalletAdapterViewModel
 import com.solana.mwallet.MobileWalletAdapterViewModel.MobileWalletAdapterServiceRequest
 import com.solana.mwallet.R
@@ -39,6 +40,8 @@ class AuthorizeDappFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        viewBinding.textInfo.text = getPublicAddressText()
 
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.CREATED) {
@@ -91,6 +94,11 @@ class AuthorizeDappFragment : Fragment() {
             }
         }
     }
+
+    private fun getPublicAddressText(): String =
+        runCatching { LocalKeypair.getPublicKey() }.getOrNull()
+            ?.let { getString(R.string.label_share_public_address, it) }
+            ?: getString(R.string.label_public_address_not_configured)
 
     companion object {
         private val TAG = AuthorizeDappFragment::class.simpleName

--- a/app/src/main/res/layout/fragment_authorize_dapp.xml
+++ b/app/src/main/res/layout/fragment_authorize_dapp.xml
@@ -50,7 +50,8 @@
         android:layout_marginTop="24dp"
         app:layout_constraintTop_toBottomOf="@id/text_subtitle"
         app:layout_constraintStart_toStartOf="parent"
-        android:text="You'll share your public address with this app." />
+        app:layout_constraintEnd_toEndOf="parent"
+        android:text="@string/label_public_address_not_configured" />
 
     <View
         android:id="@+id/divider"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
 
     <!-- Authorize dapp fragment strings -->
     <string name="label_authorize_dapp">Authorize dapp</string>
+    <string name="label_public_address_not_configured">Public address not configured</string>
+    <string name="label_share_public_address">You\'ll share this public address with this app:\n%1$s</string>
     <string name="label_verification_state">Status:</string>
     <string name="label_verification_scope">Scope:</string>
     <string name="label_simulate_cluster_not_supported">Simulate cluster not supported</string>


### PR DESCRIPTION
Read the configured LocalKeypair public key in the authorize flow and show it in the address sharing copy.

Move the static dialog copy into string resources and constrain the text view so long addresses wrap.

<img width="528" height="1063" alt="image" src="https://github.com/user-attachments/assets/4befd4a9-0e82-4873-80a5-786c9d52e089" />
