### PR TITLE
feat: allow configurable wallet name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ This should be a private key that is strictly used for development purposes.
 
 3. Now, when you connect to the wallet, it will authorize and sign transactions with the imported private key.
 
+### Set the wallet name
+
+By default, Mock MWA Wallet presents itself as `mwallet`.
+
+In `mock-mwa-wallet/local.properties`, you can configure the wallet name:
+
+```
+walletName=some.skr
+```
+
+Rebuild and install the app for the new wallet name to take effect.
+
 ### Authenticating on an emulator
 
 You can add Device Authentication on an emulator, just like on a physical device. 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,10 +30,12 @@ android {
 
         Properties properties = new Properties()
         properties.load(project.rootProject.file('local.properties').newDataInputStream())
-        def privateKey = properties.getProperty('privateKey')
         def blowfishApiKey = properties.getProperty('blowfishApiKey')
-        buildConfigField "String", "PRIVATE_KEY", privateKey ? "\"$privateKey\"" : "null"
+        def privateKey = properties.getProperty('privateKey')
+        def walletName = properties.getProperty('walletName')
         buildConfigField "String", "BLOWFISH_API_KEY", blowfishApiKey ? "\"$blowfishApiKey\"" : "null"
+        buildConfigField "String", "PRIVATE_KEY", privateKey ? "\"$privateKey\"" : "null"
+        buildConfigField "String", "WALLET_NAME", walletName ? "\"$walletName\"" : "\"mwallet\""
     }
 
     testOptions {

--- a/app/src/main/java/com/solana/mwallet/MainActivity.kt
+++ b/app/src/main/java/com/solana/mwallet/MainActivity.kt
@@ -23,6 +23,7 @@ class MainActivity : AppCompatActivity() {
         viewBinding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(viewBinding.root)
 
+        viewBinding.titleText.text = "Name: ${BuildConfig.WALLET_NAME}"
         viewBinding.publicKeyText.text = getPublicKeyText()
 
         viewBinding.button.setOnClickListener {
@@ -67,6 +68,6 @@ class MainActivity : AppCompatActivity() {
 
     private fun getPublicKeyText(): String =
         runCatching { LocalKeypair.getPublicKey() }.getOrNull()
-            ?.let { "Public key: $it" }
-            ?: "Public key not configured"
+            ?.let { "Address: $it" }
+            ?: "Address not configured"
 }

--- a/app/src/main/java/com/solana/mwallet/MobileWalletAdapterViewModel.kt
+++ b/app/src/main/java/com/solana/mwallet/MobileWalletAdapterViewModel.kt
@@ -39,6 +39,7 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
     private var scenario: Scenario? = null
 
     private val walletIconUri = Uri.parse(application.getString(R.string.wallet_icon_uri))
+    private val walletName = BuildConfig.WALLET_NAME
 
     private val scanTransactionsUseCase = ScanTransactionsUseCase(
         viewModelScope,
@@ -79,7 +80,7 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
                     ProtocolContract.FEATURE_ID_SIGN_IN_WITH_SOLANA
                 )
             ),
-            AuthIssuerConfig("mwallet"),
+            AuthIssuerConfig(walletName),
             MobileWalletAdapterScenarioCallbacks()
         ).also { it.start() }
 
@@ -112,7 +113,7 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
                     return@launch
                 }.public as Ed25519PublicKeyParameters
                 Log.d(TAG, "authorizeDapp: Got keypair successfully")
-                val account = buildAccount(publicKey.encoded, "mwallet",
+                val account = buildAccount(publicKey.encoded, walletName,
                     chains = arrayOf(request.request.chain),
                     features = arrayOf(
                         ProtocolContract.FEATURE_ID_SIGN_TRANSACTIONS,
@@ -186,7 +187,7 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
                 val signInResult = SignInResult(publicKey.encoded,
                     siwsMessage.encodeToByteArray(), signResult.signature, "ed25519")
 
-                val account = buildAccount(publicKey.encoded, "mwallet")
+                val account = buildAccount(publicKey.encoded, walletName)
                 // Get the current request from state (may have been updated by verification callback)
                 val currentRequest = _mobileWalletAdapterServiceEvents.value
                 if (currentRequest is MobileWalletAdapterServiceRequest.SignIn &&

--- a/app/src/main/java/com/solana/mwallet/usecase/UserAuthenticationUseCase.kt
+++ b/app/src/main/java/com/solana/mwallet/usecase/UserAuthenticationUseCase.kt
@@ -5,11 +5,12 @@ import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import com.solana.mwallet.BuildConfig
 
 object UserAuthenticationUseCase {
 
     private val promptInfo: BiometricPrompt.PromptInfo = BiometricPrompt.PromptInfo.Builder()
-        .setTitle("Log in to mwallet")
+        .setTitle("Log in to ${BuildConfig.WALLET_NAME}")
         .setSubtitle("Log in securely access your accounts")
         .setAllowedAuthenticators(Authenticators.BIOMETRIC_STRONG or Authenticators.DEVICE_CREDENTIAL)
         .build()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,11 +14,11 @@
         android:id="@+id/title_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/label_hello_world"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Name: wallet name" />
 
     <TextView
         android:id="@+id/public_key_text"
@@ -33,7 +33,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/title_text"
-        tools:text="Public key: 11111111111111111111111111111111" />
+        tools:text="Address: 11111111111111111111111111111111" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/button"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,9 +5,6 @@
 <resources>
     <string name="app_name">Mock MWA Wallet</string>
 
-    <!-- Main activity strings -->
-    <string name="label_hello_world">I\'m a wallet!</string>
-
     <!-- Authorize dapp fragment strings -->
     <string name="label_authorize_dapp">Authorize dapp</string>
     <string name="label_public_address_not_configured">Public address not configured</string>


### PR DESCRIPTION
Read walletName from local.properties into BuildConfig with mwallet as the default.

Use the configured wallet name for the Mobile Wallet Adapter issuer, account label, and biometric prompt title, and document the local setting

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/49a1ced5-0b00-4c4e-914a-c45dfb85de25" />
