### PR TITLE
chore: add local.properties setup task

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,17 @@ git clone https://github.com/solana-mobile/mock-mwa-wallet.git
 
 2. Open the project on Android Studio > Open > `mock-mwa-wallet/build.gradle`
 
-3. **Optional:** Import an existing private key in `local.properties` to use in the wallet. See [Import a private key](#import-a-private-key).
+3. **Optional:** Create a development `local.properties` with a fixed private key and wallet name:
 
-4. Build the app and install on any Android device or emulator.
+```bash
+./gradlew setup
+```
+
+This creates `local.properties` only if it does not already exist. The generated wallet name is `mock.mwa`.
+
+4. **Optional:** Import an existing private key in `local.properties` to use in the wallet. See [Import a private key](#import-a-private-key).
+
+5. Build the app and install on any Android device or emulator.
 
 ## Testing Your App
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,9 +27,11 @@ android {
         manifestPlaceholders = [ walletUriHost: "solanamobile.com", walletUriPath: "/mwallet/"]
         buildConfigField "android.net.Uri",
                 "WALLET_URI_BASE", "android.net.Uri.parse(\"https://solanamobile.com/mwallet/\")"
-
         Properties properties = new Properties()
-        properties.load(project.rootProject.file('local.properties').newDataInputStream())
+        def localPropertiesFile = project.rootProject.file('local.properties')
+        if (localPropertiesFile.exists()) {
+            properties.load(localPropertiesFile.newDataInputStream())
+        }
         def blowfishApiKey = properties.getProperty('blowfishApiKey')
         def privateKey = properties.getProperty('privateKey')
         def walletName = properties.getProperty('walletName')

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@
  * Copyright (c) 2022 Solana Mobile Inc.
  */
 
+import java.security.SecureRandom
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 // Add Navigation safe-args support
@@ -23,6 +25,26 @@ plugins {
     alias libs.plugins.koltin.ksp apply false
 }
 
+def localPropertiesSetupFile = layout.projectDirectory.file('local.properties').asFile
+
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+tasks.register('setup') {
+    description = 'Creates local.properties with mock wallet defaults if missing.'
+    group = 'setup'
+
+    doLast { task ->
+        if (localPropertiesSetupFile.exists()) {
+            task.logger.lifecycle('local.properties already exists; leaving it unchanged.')
+            return
+        }
+
+        byte[] privateKey = new byte[32]
+        new SecureRandom().nextBytes(privateKey)
+
+        localPropertiesSetupFile.text = "privateKey=${privateKey.encodeBase64().toString().replace('=', '')}\nwalletName=mock.mwa\n"
+        task.logger.lifecycle('Created local.properties.')
+    }
 }


### PR DESCRIPTION
Add a Gradle setup task that creates local.properties with a generated privateKey and mock.mwa walletName when the file is missing.

Allow app/build.gradle to configure without an existing local.properties file, preserving the existing BuildConfig defaults.

Document the setup step for fresh local checkouts.